### PR TITLE
Use newer migrateProtocol function and log output

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "network-canvas"]
 	path = network-canvas
-	url = https://github.com/codaco/network-canvas.git
+	url = https://github.com/complexdatacollective/network-canvas.git
 [submodule "src/protocol-validation"]
 	path = src/protocol-validation
-	url = https://github.com/codaco/protocol-validation.git
+	url = https://github.com/complexdatacollective/protocol-validation.git
 [submodule "development-protocol"]
 	path = development-protocol
-	url = https://github.com/codaco/development-protocol.git
+	url = https://github.com/complexdatacollective/development-protocol.git

--- a/src/ducks/modules/protocols/unbundle.js
+++ b/src/ducks/modules/protocols/unbundle.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import log from 'electron-log';
 import { APP_SCHEMA_VERSION } from '@app/config';
 import canUpgrade from '@app/protocol-validation/migrations/canUpgrade';
 import getMigrationNotes from '@app/protocol-validation/migrations/getMigrationNotes';
@@ -74,7 +75,9 @@ const migrateProtocolThunk = ({ protocol, filePath, workingPath }) =>
         return getNewFileName(filePath)
           .then(({ canceled, filePath: newFilePath }) => {
             if (canceled) { return null; }
-            const updatedProtocol = migrateProtocol(protocol, APP_SCHEMA_VERSION);
+            const [updatedProtocol, migrationSteps] = migrateProtocol(protocol, APP_SCHEMA_VERSION);
+
+            log.info(`Protocol ${filePath} migrated from ${protocol.schemaVersion} to ${APP_SCHEMA_VERSION}`, { migrationSteps });
 
             return saveProtocol(workingPath, updatedProtocol)
               .then(() => bundleProtocol(workingPath, newFilePath))


### PR DESCRIPTION
Update to support the changes in protocol-validation added here: https://github.com/complexdatacollective/protocol-validation/pull/41

- Update version protocol-validation which supports schemaVersion "1.0.0"
- Update usage of migrateProtocol to capture migrationSteps
- Log migrationSteps to electron

Resolves https://github.com/complexdatacollective/Architect/issues/665