### PR TITLE
Edit types in codebook

### DIFF
--- a/src/components/Codebook/EntityType.js
+++ b/src/components/Codebook/EntityType.js
@@ -83,6 +83,7 @@ EntityType.propTypes = {
   usage: PropTypes.array.isRequired,
   inUse: PropTypes.bool,
   handleDelete: PropTypes.func.isRequired,
+  handleEdit: PropTypes.func.isRequired,
   closeCodebook: PropTypes.func.isRequired,
   variables: PropTypes.array,
 };

--- a/src/components/Codebook/EntityType.js
+++ b/src/components/Codebook/EntityType.js
@@ -47,7 +47,6 @@ const EntityType = ({
         <div className="codebook__entity-control">
           <Button
             size="small"
-            color="neon-coral"
             onClick={handleEdit}
           >
             Edit entity

--- a/src/components/Codebook/EntityType.js
+++ b/src/components/Codebook/EntityType.js
@@ -112,7 +112,7 @@ const withEntityHandlers = compose(
       () => closeScreen('codebook'),
     handleEdit: ({ openScreen, entity, type }) =>
       () => {
-        openScreen('type', { entity, type });
+        openScreen('type', { entity, type, metaOnly: true });
       },
     handleDelete: ({ deleteType, openDialog, entity, type, name, inUse }) =>
       () => {

--- a/src/components/Codebook/EntityType.js
+++ b/src/components/Codebook/EntityType.js
@@ -21,6 +21,7 @@ const EntityType = ({
   type,
   variables,
   closeCodebook,
+  handleEdit,
   handleDelete,
 }) => {
   const stages = usage
@@ -44,6 +45,13 @@ const EntityType = ({
           { inUse && <React.Fragment><em>used in:</em> {stages}</React.Fragment> }
         </div>
         <div className="codebook__entity-control">
+          <Button
+            size="small"
+            color="neon-coral"
+            onClick={handleEdit}
+          >
+            Edit entity
+          </Button>
           <Button
             size="small"
             color="neon-coral"
@@ -83,6 +91,7 @@ EntityType.defaultProps = {
   variables: [],
   inUse: true, // Don't allow delete unless we explicitly say so
   handleDelete: () => {},
+  handleEdit: () => {},
 };
 
 const mapStateToProps = (state, { entity, type }) => {
@@ -96,10 +105,15 @@ const withEntityHandlers = compose(
     openDialog: dialogActionCreators.openDialog,
     deleteType: codebookActionCreators.deleteType,
     closeScreen: screenActionsCreators.closeScreen,
+    openScreen: screenActionsCreators.openScreen,
   }),
   withHandlers({
     closeCodebook: ({ closeScreen }) =>
       () => closeScreen('codebook'),
+    handleEdit: ({ openScreen, entity, type }) =>
+      () => {
+        openScreen('type', { entity, type });
+      },
     handleDelete: ({ deleteType, openDialog, entity, type, name, inUse }) =>
       () => {
         if (inUse) {

--- a/src/components/TypeEditor/TypeEditor.js
+++ b/src/components/TypeEditor/TypeEditor.js
@@ -25,6 +25,7 @@ const TypeEditor = ({
   displayVariables,
   existingTypes,
   isNew,
+  metaOnly,
 }) => {
   const { name: paletteName, size: paletteSize } = getPalette(entity);
 
@@ -96,7 +97,7 @@ const TypeEditor = ({
         </React.Fragment>
       }
 
-      {!isNew &&
+      {(!isNew && !metaOnly) &&
         <Section>
           <Variables
             form={form}
@@ -120,12 +121,14 @@ TypeEditor.propTypes = {
   displayVariables: PropTypes.array.isRequired,
   existingTypes: PropTypes.array.isRequired,
   isNew: PropTypes.bool,
+  metaOnly: PropTypes.bool,
 };
 
 TypeEditor.defaultProps = {
   type: null,
   colorOptions: { node: [], edge: [] },
   isNew: false,
+  metaOnly: false,
 };
 
 const mapStateToProps = (state) => {

--- a/src/components/TypeEditor/TypeEditor.js
+++ b/src/components/TypeEditor/TypeEditor.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Field } from 'redux-form';
 import PropTypes from 'prop-types';
-import { capitalize, values } from 'lodash';
+import { capitalize, toPairs } from 'lodash';
 import * as Fields from '@codaco/ui/lib/components/Fields';
 import { getFieldId } from '@app/utils/issues';
 import { ValidatedField } from '@components/Form';
@@ -131,11 +131,21 @@ TypeEditor.defaultProps = {
   metaOnly: false,
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, { type, isNew }) => {
   const codebook = getCodebook(state);
 
-  const nodes = values(codebook.node).map(node => node.name);
-  const edges = values(codebook.edge).map(edge => edge.name);
+  const getNames = (codebookTypeDefinitions, excludeType) =>
+    toPairs(codebookTypeDefinitions)
+      .reduce((acc, [id, definition]) => {
+        if (excludeType && id === excludeType) { return acc; }
+        return [
+          ...acc,
+          definition.name,
+        ];
+      }, []);
+
+  const nodes = getNames(codebook.node, !isNew && type);
+  const edges = getNames(codebook.edge, !isNew && type);
 
   const existingTypes = [
     ...nodes,


### PR DESCRIPTION
Add edit button to nodes and edges in codebook, allowing the editing of name/color/icon.

Resolves #675 