### PR TITLE
restrict additional attributes to boolean

### DIFF
--- a/src/components/AssignAttributes/AssignAttributes.js
+++ b/src/components/AssignAttributes/AssignAttributes.js
@@ -7,6 +7,7 @@ import NewVariableWindow from '../NewVariableWindow';
 
 const AssignAttributes = ({
   variableOptions,
+  allowedVariableTypes,
   fields,
   type,
   entity,
@@ -48,6 +49,7 @@ const AssignAttributes = ({
     </div>
 
     <NewVariableWindow
+      allowVariableTypes={allowedVariableTypes}
       show={showNewVariableWindow}
       onComplete={handleCreateNewVariable}
       onCancel={handleCompleteCreateNewVariable}
@@ -59,6 +61,7 @@ const AssignAttributes = ({
 
 AssignAttributes.propTypes = {
   variableOptions: PropTypes.array.isRequired,
+  allowedVariableTypes: PropTypes.array.isRequired,
   fields: PropTypes.object.isRequired,
   type: PropTypes.string.isRequired,
   entity: PropTypes.string.isRequired,

--- a/src/components/AssignAttributes/withAssignAttributesHandlers.js
+++ b/src/components/AssignAttributes/withAssignAttributesHandlers.js
@@ -5,13 +5,7 @@ import { getVariableOptionsForSubject } from '../../selectors/codebook';
 import { actionCreators as codebookActions } from '../../ducks/modules/protocol/codebook';
 
 const ALLOWED_TYPES = [
-  'text',
-  'number',
   'boolean',
-  'ordinal',
-  'categorical',
-  'scalar',
-  'datetime',
 ];
 
 // TODO: isUsed
@@ -30,6 +24,7 @@ const mapStateToProps = (state, { entity, type, form, fields }) => {
 
   return {
     variableOptions: variableOptionsWithUsedDisabled,
+    allowedVariableTypes: ALLOWED_TYPES,
   };
 };
 


### PR DESCRIPTION
Updates the UI for additional attributes to only allow boolean values, and updates the protocol-validation as well.

Still needs to update the NC reference once that is ready.