### PR TITLE
Prevent inline asset deletion

### DIFF
--- a/src/components/AssetBrowser/AssetBrowser.js
+++ b/src/components/AssetBrowser/AssetBrowser.js
@@ -11,6 +11,7 @@ const AssetBrowser = ({
   selected,
   onSelect,
   onDelete,
+  disableDelete,
 }) => {
   const handleCreate = useCallback((assetIds) => {
     if (assetIds.length !== 1) { return; } // if multiple files were uploaded
@@ -31,6 +32,7 @@ const AssetBrowser = ({
         <Assets
           onSelect={onSelect}
           onDelete={onDelete}
+          disableDelete={disableDelete}
           selected={selected}
           type={type}
         />
@@ -44,6 +46,7 @@ AssetBrowser.propTypes = {
   selected: PropTypes.string,
   onSelect: PropTypes.func,
   onDelete: PropTypes.func,
+  disableDelete: PropTypes.bool,
 };
 
 AssetBrowser.defaultProps = {
@@ -53,6 +56,7 @@ AssetBrowser.defaultProps = {
   onSelect: () => {},
   onDelete: () => {},
   stackIndex: null,
+  disableDelete: false,
 };
 
 export default compose(

--- a/src/components/AssetBrowser/AssetBrowserWindow.js
+++ b/src/components/AssetBrowser/AssetBrowserWindow.js
@@ -44,6 +44,7 @@ const AssetBrowserWindow = ({
             type={type}
             onSelect={onSelect}
             selected={selected}
+            disableDelete
           />
         </SimpleDialog>
       )}

--- a/src/components/AssetBrowser/Assets.js
+++ b/src/components/AssetBrowser/Assets.js
@@ -20,13 +20,16 @@ const Assets = ({
   onUpdateAssetFilter,
   onSelect,
   onDelete,
+  disableDelete,
 }) => {
+  const handleDelete = !disableDelete && onDelete;
+
   const renderedAssets = assets.map(asset => (
     <div className="asset-browser-assets__asset" key={asset.id}>
       <Thumbnail
         {...asset}
         onClick={onSelect}
-        onDelete={onDelete}
+        onDelete={handleDelete}
       />
     </div>
   ));

--- a/src/components/AssetBrowser/Assets.js
+++ b/src/components/AssetBrowser/Assets.js
@@ -64,6 +64,7 @@ Assets.propTypes = {
   assets: PropTypes.array,
   assetType: PropTypes.string,
   onUpdateAssetFilter: PropTypes.func.isRequired,
+  disableDelete: PropTypes.bool,
 };
 
 Assets.defaultProps = {
@@ -72,6 +73,7 @@ Assets.defaultProps = {
   onDelete: null,
   assets: [],
   assetType: null,
+  disableDelete: false,
 };
 
 export default compose(

--- a/src/components/sections/Background/Background.js
+++ b/src/components/sections/Background/Background.js
@@ -71,10 +71,12 @@ class Background extends PureComponent {
         { (useImage) &&
           <Row>
             <div style={{ position: 'relative', minHeight: '100px' }}>
-              <Field
+              <div id={getFieldId('background.image')} data-name="Background &gt; Image" />
+              <ValidatedField
                 name="background.image"
                 component={ArchitectFields.Image}
                 label="Background image"
+                validation={{ required: true }}
               />
             </div>
           </Row>


### PR DESCRIPTION
Deleting assets in the browser window can have a number of side-effects which are difficult to handle.

This PR disables inline deletion - assets can only be deleted in the resource library.