### PR TITLE
Show issues panel only on submit

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, Form, getFormSyncErrors } from 'redux-form';
 import PropTypes from 'prop-types';
@@ -52,6 +52,8 @@ const Editor = ({
   handleSubmit,
   toggleCodeView,
   showCodeView,
+  updateShowIssues,
+  showIssues,
   form,
   children,
   issues,
@@ -59,28 +61,38 @@ const Editor = ({
   submitFailed,
   component: Component,
   ...rest
-}) => (
-  <React.Fragment>
-    <FormCodeView toggleCodeView={toggleCodeView} form={form} show={showCodeView} />
-    <Form onSubmit={handleSubmit}>
-      { typeof children === 'function' &&
-        children({ form, toggleCodeView, submitFailed, ...rest })
-      }
-      { children && typeof children !== 'function' && children }
-      { !children &&
-        <Component form={form} submitFailed={submitFailed} {...rest} />
-      }
-    </Form>
-    <Issues
-      issues={issues}
-      show={submitFailed}
-    />
-  </React.Fragment>
-);
+}) => {
+  useEffect(() => {
+    if (Object.keys(issues).length === 0) {
+      updateShowIssues(false);
+    }
+  }, [Object.keys(issues).length]);
+
+  return (
+    <React.Fragment>
+      <FormCodeView toggleCodeView={toggleCodeView} form={form} show={showCodeView} />
+      <Form onSubmit={handleSubmit}>
+        { typeof children === 'function' &&
+          children({ form, toggleCodeView, submitFailed, ...rest })
+        }
+        { children && typeof children !== 'function' && children }
+        { !children &&
+          <Component form={form} submitFailed={submitFailed} {...rest} />
+        }
+      </Form>
+      <Issues
+        issues={issues}
+        show={showIssues}
+      />
+    </React.Fragment>
+  );
+};
 
 Editor.propTypes = {
   toggleCodeView: PropTypes.func.isRequired,
   showCodeView: PropTypes.bool.isRequired,
+  updateShowIssues: PropTypes.func.isRequired,
+  showIssues: PropTypes.bool.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   issues: PropTypes.object.isRequired,
   submitFailed: PropTypes.bool.isRequired,
@@ -108,8 +120,10 @@ export { Editor };
 
 export default compose(
   withState('showCodeView', 'updateCodeView', false),
+  withState('showIssues', 'updateShowIssues', false),
   withHandlers({
     toggleCodeView: ({ updateCodeView }) => () => updateCodeView(current => !current),
+    onSubmitFail: ({ updateShowIssues }) => () => { updateShowIssues(true); },
   }),
   reduxForm({
     touchOnBlur: false,

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, Form, getFormSyncErrors } from 'redux-form';
 import PropTypes from 'prop-types';
@@ -50,8 +50,6 @@ import Issues from './Issues';
  */
 const Editor = ({
   handleSubmit,
-  toggleCodeView,
-  showCodeView,
   updateShowIssues,
   showIssues,
   form,
@@ -62,6 +60,9 @@ const Editor = ({
   component: Component,
   ...rest
 }) => {
+  const [showCodeView, setCodeView] = useState(false);
+  const toggleCodeView = () => setCodeView(value => !value);
+
   useEffect(() => {
     if (Object.keys(issues).length === 0) {
       updateShowIssues(false);
@@ -89,8 +90,6 @@ const Editor = ({
 };
 
 Editor.propTypes = {
-  toggleCodeView: PropTypes.func.isRequired,
-  showCodeView: PropTypes.bool.isRequired,
   updateShowIssues: PropTypes.func.isRequired,
   showIssues: PropTypes.bool.isRequired,
   handleSubmit: PropTypes.func.isRequired,
@@ -119,10 +118,8 @@ const mapStateToProps = (state, props) => {
 export { Editor };
 
 export default compose(
-  withState('showCodeView', 'updateCodeView', false),
   withState('showIssues', 'updateShowIssues', false),
   withHandlers({
-    toggleCodeView: ({ updateCodeView }) => () => updateCodeView(current => !current),
     onSubmitFail: ({ updateShowIssues }) => () => { updateShowIssues(true); },
   }),
   reduxForm({

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { reduxForm, Form, getFormSyncErrors, hasSubmitFailed } from 'redux-form';
+import { reduxForm, Form, getFormSyncErrors } from 'redux-form';
 import PropTypes from 'prop-types';
 import { compose, withState, withHandlers } from 'recompose';
 import { FormCodeView } from './CodeView';
@@ -64,11 +64,11 @@ const Editor = ({
     <FormCodeView toggleCodeView={toggleCodeView} form={form} show={showCodeView} />
     <Form onSubmit={handleSubmit}>
       { typeof children === 'function' &&
-        children({ form, toggleCodeView, ...rest })
+        children({ form, toggleCodeView, submitFailed, ...rest })
       }
       { children && typeof children !== 'function' && children }
       { !children &&
-        <Component form={form} {...rest} />
+        <Component form={form} submitFailed={submitFailed} {...rest} />
       }
     </Form>
     <Issues
@@ -101,7 +101,6 @@ const mapStateToProps = (state, props) => {
 
   return {
     issues,
-    hasSubmitFailed: hasSubmitFailed(props.form)(state),
   };
 };
 

--- a/src/components/Screens/__tests__/__snapshots__/TypeEditorScreen.test.js.snap
+++ b/src/components/Screens/__tests__/__snapshots__/TypeEditorScreen.test.js.snap
@@ -7,7 +7,7 @@ exports[`<TypeEditorScreen /> can render 1`] = `
       "$$typeof": Symbol(react.memo),
       "WrappedComponent": [Function],
       "compare": null,
-      "displayName": "Connect(withProps(withHandlers(withState(withHandlers(ReduxForm)))))",
+      "displayName": "Connect(withProps(withHandlers(withStateHandlers(ReduxForm))))",
       "type": [Function],
     }
   }


### PR DESCRIPTION
Editor now keeps an internal state which resets when all issues are resolved. At which point the issues panel will only appear again when the form is submitted.

Resolves #231