### PR TITLE
pass form prop into nodepanel network filter

### DIFF
--- a/src/components/sections/NodePanels/NodePanel.js
+++ b/src/components/sections/NodePanels/NodePanel.js
@@ -7,8 +7,8 @@ import { Item, Row } from '@components/OrderedList';
 import { getFieldId } from '@app/utils/issues';
 import NetworkFilter from '@components/sections/fields/NetworkFilter';
 
-const NodePanel = ({ fieldId, ...rest }) => (
-  <Item {...rest}>
+const NodePanel = ({ fieldId, form, ...rest }) => (
+  <Item form={form} {...rest}>
     <Row>
       <h3 id={getFieldId(`${fieldId}.title`)}>Panel title</h3>
       <p>The panel title will be shown above the list of nodes within the panel.</p>
@@ -37,6 +37,7 @@ const NodePanel = ({ fieldId, ...rest }) => (
       />
     </Row>
     <NetworkFilter
+      form={form}
       variant="contrast"
       name={`${fieldId}.filter`}
       title="Filter nodes displayed in this panel"
@@ -46,6 +47,7 @@ const NodePanel = ({ fieldId, ...rest }) => (
 
 NodePanel.propTypes = {
   fieldId: PropTypes.string.isRequired,
+  form: PropTypes.string.isRequired,
 };
 
 export { NodePanel };

--- a/src/components/sections/fields/NetworkFilter.js
+++ b/src/components/sections/fields/NetworkFilter.js
@@ -17,6 +17,7 @@ import {
 const FilterField = withFieldConnector(withStoreConnector(FilterQuery));
 
 const NetworkFilter = ({
+  form,
   hasFilter,
   changeField,
   openDialog,
@@ -35,13 +36,13 @@ const NetworkFilter = ({
         })
           .then((confirm) => {
             if (confirm) {
-              changeField('edit-stage', name, null);
+              changeField(form, name, null);
             }
             return confirm;
           });
       }
 
-      changeField('edit-stage', name, null);
+      changeField(form, name, null);
       return Promise.resolve(true);
     },
     [openDialog, changeField],
@@ -69,6 +70,7 @@ const NetworkFilter = ({
 };
 
 NetworkFilter.propTypes = {
+  form: PropTypes.string.isRequired,
   hasFilter: PropTypes.bool.isRequired,
   changeField: PropTypes.func.isRequired,
   openDialog: PropTypes.func.isRequired,

--- a/src/styles/components/rules/_rules.scss
+++ b/src/styles/components/rules/_rules.scss
@@ -1,5 +1,6 @@
 .rules-rules {
   &__join {
+    --input-border: var(--text);
     margin-top: unit(4);
   }
 


### PR DESCRIPTION
This PR fixes a bug that caused the network filter component not to register as being 'active' when used in a name generator node panel. This was caused by failing to pass through a form prop, which the component uses to check if a filter has been set.

It also fixes the styling of the join rule radio group, which was not compatible with a white background container.