### PR TITLE
Prevent timeline middleware from going to non-existent point in history

### DIFF
--- a/src/ducks/middleware/__tests__/timeline.test.js
+++ b/src/ducks/middleware/__tests__/timeline.test.js
@@ -84,6 +84,23 @@ describe('timeline middleware', () => {
       expect(rollbackState.timeline).toEqual(nextState.timeline.slice(0, 5));
       expect(rollbackState.present).toEqual(nextState.past[4]);
     });
+
+    it('if point does not exist it ignores action', () => {
+      const nextState = times(10)
+        .reduce(
+          (state) => rewindableReducer(state, {}),
+          undefined,
+        );
+
+      const rollbackState = rewindableReducer(
+        nextState,
+        actionCreators.jump('NON_EXISTENT_POINT'),
+      );
+
+      expect(rollbackState.past).toEqual(nextState.past);
+      expect(rollbackState.timeline).toEqual(nextState.timeline);
+      expect(rollbackState.present).toEqual(nextState.present);
+    });
   });
 
   describe('reset() action', () => {

--- a/src/ducks/middleware/timeline.js
+++ b/src/ducks/middleware/timeline.js
@@ -37,6 +37,11 @@ const createTimelineReducer = (reducer, customOptions) => {
       if (!action.payload.locus) { return state; }
       const locusIndex = timeline.indexOf(action.payload.locus);
 
+      // If point in timeline cannot be found do nothing
+      if (locusIndex === -1) {
+        return state;
+      }
+
       // no events in timeline yet
       if (timeline.length === 1) {
         return state;


### PR DESCRIPTION
Partial fix for: https://github.com/complexdatacollective/Architect/issues/715