### PR TITLE
Release/6.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.2.0",
+    "version": "6.2.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.2.1",
+    "version": "6.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.2.0",
+    "version": "6.2.1",
     "productName": "Network Canvas Architect",
     "description": "A tool for building Network Canvas interviews.",
     "author": "Complex Data Collective <info@networkcanvas.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.2.1",
+    "version": "6.2.2",
     "productName": "Network Canvas Architect",
     "description": "A tool for building Network Canvas interviews.",
     "author": "Complex Data Collective <info@networkcanvas.com>",

--- a/public/package.json
+++ b/public/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.2.1",
+    "version": "6.2.2",
     "productName": "Network Canvas Architect",
     "description": "A tool for building Network Canvas interviews.",
     "author": "Complex Data Collective",

--- a/public/package.json
+++ b/public/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.2.0",
+    "version": "6.2.1",
     "productName": "Network Canvas Architect",
     "description": "A tool for building Network Canvas interviews.",
     "author": "Complex Data Collective",

--- a/src/hooks/useUpdater.js
+++ b/src/hooks/useUpdater.js
@@ -102,7 +102,7 @@ const useUpdater = (updateEndpoint, timeout = 0) => {
           <Markdown
             className="dialog-release-notes__notes"
             markdownRenderers={markdownComponents}
-            source={releaseNotes}
+            label={releaseNotes}
           />
         </div>
       ),

--- a/src/lib/ProtocolSummary/components/Stage/Presets.js
+++ b/src/lib/ProtocolSummary/components/Stage/Presets.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import MiniTable from '../MiniTable';
 import EntityBadge from '../EntityBadge';
 import Variable from '../Variable';
-import { get } from 'lodash';
 
 const Presets = ({ presets }) => {
   if (!presets) { return null; }
-  console.log('presets', presets);
+
   return (
     <div className="protocol-summary-stage__presets">
       <div className="protocol-summary-stage__presets-content">

--- a/src/lib/ProtocolSummary/components/Stage/Presets.js
+++ b/src/lib/ProtocolSummary/components/Stage/Presets.js
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types';
 import MiniTable from '../MiniTable';
 import EntityBadge from '../EntityBadge';
 import Variable from '../Variable';
+import { get } from 'lodash';
 
 const Presets = ({ presets }) => {
   if (!presets) { return null; }
-
+  console.log('presets', presets);
   return (
     <div className="protocol-summary-stage__presets">
       <div className="protocol-summary-stage__presets-content">
@@ -26,7 +27,7 @@ const Presets = ({ presets }) => {
                       'Show edges',
                       <ul>
                         {
-                          preset.edges.display.map((edge) => (
+                          get(preset, 'edges.display', []).map((edge) => (
                             <li key={edge}>
                               <EntityBadge entity="edge" type={edge} tiny link />
                             </li>
@@ -39,7 +40,7 @@ const Presets = ({ presets }) => {
                       'Highlight attributes',
                       <ul>
                         {
-                          preset.highlight.map((id) => (
+                          get(preset, 'preset.highlight', []).map((id) => (
                             <li key={id}>
                               <Variable id={id} link />
                               <br />


### PR DESCRIPTION
## Network Canvas Architect 6.2.2

This release fixes an issue with displaying release notes, and should be installed by all users currently using version 6.2.1 or 6.2.0. 

Users on versions prior to 6.2.0 should refer to the release notes for 6.2.0 before deciding to upgrade: [https://github.com/complexdatacollective/Architect/releases/tag/v6.2.0](https://github.com/complexdatacollective/Architect/releases/tag/v6.2.0)

### Changelog:
- Fixed an issue that prevented release notes from being displayed within the app