### PR TITLE
Fix/validation initial state

### DIFF
--- a/src/components/sections/Form/FieldFields.js
+++ b/src/components/sections/Form/FieldFields.js
@@ -206,7 +206,7 @@ PromptFields.propTypes = {
   variableType: PropTypes.string,
   handleChangeComponent: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
-  metaForType: PropTypes.object.isRequired,
+  metaForType: PropTypes.object,
   // eslint-disable-next-line react/forbid-prop-types
   variableOptions: PropTypes.array,
   // eslint-disable-next-line react/forbid-prop-types
@@ -224,6 +224,7 @@ PromptFields.defaultProps = {
   component: null,
   variableType: null,
   variableOptions: null,
+  metaForType: {},
   componentOptions: null,
   entity: null,
   type: null,

--- a/src/components/sections/Form/withFieldsHandlers.js
+++ b/src/components/sections/Form/withFieldsHandlers.js
@@ -72,7 +72,7 @@ const fieldsHandlers = withHandlers({
     // If we have changed type, also reset validation since options may not be
     // applicable.
     if (variableType !== typeForComponent) {
-      changeField(form, 'validation', {});
+      changeField(form, 'validation', null);
       changeField(form, 'options', null);
     // Special case for boolean, where BooleanChoice has options but Toggle doesn't
     } else if (variableType === 'boolean') {
@@ -86,7 +86,7 @@ const fieldsHandlers = withHandlers({
     // Either load settings from codebook, or reset
     const options = get(existingVariables, [value, 'options'], null);
     const parameters = get(existingVariables, [value, 'parameters'], null);
-    const validation = get(existingVariables, [value, 'validation'], {});
+    const validation = get(existingVariables, [value, 'validation'], null);
     const component = get(existingVariables, [value, 'component'], null);
 
     // If value was set to something from codebook, reset this flag

--- a/src/components/sections/ValidationSection.js
+++ b/src/components/sections/ValidationSection.js
@@ -53,7 +53,7 @@ const ValidationSection = ({
 ValidationSection.propTypes = {
   disabled: PropTypes.bool,
   form: PropTypes.string.isRequired,
-  variableType: PropTypes.string.isRequired,
+  variableType: PropTypes.string,
   existingVariables: PropTypes.objectOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,
@@ -62,6 +62,7 @@ ValidationSection.propTypes = {
 };
 
 ValidationSection.defaultProps = {
+  variableType: '',
   disabled: false,
 };
 


### PR DESCRIPTION
Ensures validation is reset to `null` so that it doesn't start off enabled when there are no existing validations.