### PR TITLE
update interviewer reference to 6.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "productName": "Network Canvas Architect",
     "description": "A tool for building Network Canvas interviews.",
     "author": "Complex Data Collective <info@networkcanvas.com>",

--- a/public/package.json
+++ b/public/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "productName": "Network Canvas Architect",
     "description": "A tool for building Network Canvas interviews.",
     "author": "Complex Data Collective",


### PR DESCRIPTION
## Network Canvas Architect 6.3.1

This is a small bugfix release, that includes an updated version of Interviewer that resolves a bug in the rendering of the categorical bin "other" option dialogue. It should be installed by all users currently running version 6.3.0 of Architect.

Users running versions prior to this should fully read the release notes for version 6.3.0 before updating: https://github.com/complexdatacollective/Architect/releases/tag/v6.3.0

### Changelog:
- Update the version of Interviewer used in the preview mode to address a bug with rendering the "other" option on the categorical interface.