### PR TITLE
protocol summary variable pills and behaviors

### DIFF
--- a/src/lib/ProtocolSummary/components/Rule.js
+++ b/src/lib/ProtocolSummary/components/Rule.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { compose } from 'recompose';
+import RuleText from '@components/Query/Rules/PreviewText';
+import withDisplayOptions from '@components/Query/Rules/withDisplayOptions';
+
+const Rule = ({
+  type, options,
+}) => (
+  <RuleText type={type} options={options} />
+);
+
+Rule.propTypes = {
+  type: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  options: PropTypes.object.isRequired,
+};
+
+export default compose(
+  withDisplayOptions,
+)(Rule);

--- a/src/lib/ProtocolSummary/components/Rules.js
+++ b/src/lib/ProtocolSummary/components/Rules.js
@@ -1,47 +1,27 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import RuleText, { Join } from '@components/Query/Rules/PreviewText';
+import { Join } from '@components/Query/Rules/PreviewText';
 import SummaryContext from './SummaryContext';
-import { getVariableName, getEntityName } from './helpers';
-
-const labelRules = (codebook, index, rules) => rules
-  .map(({ type, options }) => {
-    const labeledOptions = {
-      ...options,
-    };
-
-    if (options.attribute) {
-      labeledOptions.attribute = getVariableName(index, options.attribute);
-    }
-
-    if (options.type) {
-      const entity = type === 'alter' ? 'node' : 'edge';
-      labeledOptions.type = getEntityName(codebook, entity, options.type);
-    }
-
-    return { type, options: labeledOptions };
-  });
+import Rule from './Rule';
 
 const Rules = ({ filter }) => {
   const {
     protocol,
-    index,
   } = useContext(SummaryContext);
 
   if (!filter) { return null; }
 
   const {
     join,
+    rules,
   } = filter;
-
-  const rules = labelRules(protocol.codebook, index, filter.rules);
 
   return (
     <div className="protocol-summary-rules">
       { rules.map(({ type, options }, n) => (
         // eslint-disable-next-line react/no-array-index-key
         <div className="protocol-summary-rules__rule" key={n}>
-          <RuleText type={type} options={options} />
+          <Rule type={type} options={options} codebook={protocol.codebook} />
           { n !== rules.length - 1 && join && <Join value={join} /> }
         </div>
       ))}

--- a/src/lib/ProtocolSummary/components/Rules.js
+++ b/src/lib/ProtocolSummary/components/Rules.js
@@ -20,10 +20,12 @@ const Rules = ({ filter }) => {
     <div className="protocol-summary-rules">
       { rules.map(({ type, options }, n) => (
         // eslint-disable-next-line react/no-array-index-key
-        <div className="protocol-summary-rules__rule" key={n}>
-          <Rule type={type} options={options} codebook={protocol.codebook} />
+        <>
+          <div className="protocol-summary-rules__rule" key={n}>
+            <Rule type={type} options={options} codebook={protocol.codebook} />
+          </div>
           { n !== rules.length - 1 && join && <Join value={join} /> }
-        </div>
+        </>
       ))}
     </div>
   );

--- a/src/lib/ProtocolSummary/components/Rules.js
+++ b/src/lib/ProtocolSummary/components/Rules.js
@@ -19,8 +19,8 @@ const Rules = ({ filter }) => {
   return (
     <div className="protocol-summary-rules">
       { rules.map(({ type, options }, n) => (
-        // eslint-disable-next-line react/no-array-index-key
         <>
+          {/* eslint-disable-next-line react/no-array-index-key */}
           <div className="protocol-summary-rules__rule" key={n}>
             <Rule type={type} options={options} codebook={protocol.codebook} />
           </div>

--- a/src/lib/ProtocolSummary/components/Stage/Behaviours.js
+++ b/src/lib/ProtocolSummary/components/Stage/Behaviours.js
@@ -1,7 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { map } from 'lodash';
 import MiniTable from '../MiniTable';
 import { renderValue } from '../helpers';
+
+const behaviorLabel = (behaviourValue, behaviourKey) => {
+  switch (behaviourKey) {
+    case 'allowRepositioning':
+      return { label: 'Repositioning enabled', value: behaviourValue };
+    case 'automaticLayout':
+      return { label: 'Automatic layout enabled', value: behaviourValue.enabled };
+    case 'minNodes':
+      return { label: 'Minimum nodes on stage', value: behaviourValue };
+    case 'maxNodes':
+      return { label: 'Maximum nodes on stage', value: behaviourValue };
+    case 'freeDraw':
+      return { label: 'Freedraw enabled', value: behaviourValue };
+    default:
+      return { label: behaviourKey, value: behaviourValue };
+  }
+};
+
+const behaviourRows = (behaviours) => map(behaviours, (behaviourValue, behaviourKey) => {
+  const labelValue = behaviorLabel(behaviourValue, behaviourKey);
+  return [
+    labelValue.label,
+    renderValue(labelValue.value),
+  ];
+});
 
 const Behaviours = ({ behaviours }) => {
   if (!behaviours) { return null; }
@@ -12,16 +38,7 @@ const Behaviours = ({ behaviours }) => {
         <h2 className="section-heading">Behaviours</h2>
         <MiniTable
           rotated
-          rows={[
-            [
-              'Repositioning enabled',
-              renderValue(behaviours.allowRepositioning),
-            ],
-            [
-              'Freedraw enabled',
-              renderValue(behaviours.freeDraw),
-            ],
-          ]}
+          rows={behaviourRows(behaviours)}
         />
       </div>
     </div>

--- a/src/lib/ProtocolSummary/components/Stage/Form.js
+++ b/src/lib/ProtocolSummary/components/Stage/Form.js
@@ -4,10 +4,7 @@ import Markdown from '@codaco/ui/lib/components/Fields/Markdown';
 import SummaryContext from '../SummaryContext';
 import MiniTable from '../MiniTable';
 import Variable from '../Variable';
-
-const getVariableMeta = (index, variable) => (
-  index.find(({ id }) => id === variable) || {}
-);
+import { getVariableMeta } from '../helpers';
 
 const Form = ({ form }) => {
   const {

--- a/src/lib/ProtocolSummary/components/Stage/Presets.js
+++ b/src/lib/ProtocolSummary/components/Stage/Presets.js
@@ -40,7 +40,7 @@ const Presets = ({ presets }) => {
                       'Highlight attributes',
                       <ul>
                         {
-                          get(preset, 'preset.highlight', []).map((id) => (
+                          get(preset, 'highlight', []).map((id) => (
                             <li key={id}>
                               <Variable id={id} link />
                               <br />

--- a/src/lib/ProtocolSummary/components/Stage/Prompt.js
+++ b/src/lib/ProtocolSummary/components/Stage/Prompt.js
@@ -13,10 +13,12 @@ const directionLabel = (direction) => (
 );
 
 const SortOrder = ({ rules }) => {
+  if (!rules) return null;
+
   const result = rules
     .map(({ property, direction }) => (
       <li key={property}>
-        <Variable id={property} />
+        {(property === '*') ? '*' : <Variable id={property} />}
         {' '}
         <small>
           (
@@ -41,7 +43,7 @@ const attributes = [
   ['highlight.allowHighlighting', 'Allow highlighting', (allow) => renderValue(allow)],
   ['highlight.variable', 'Highlight variable', (id) => <Variable id={id} />],
   ['negativeLabel', 'Negative Option Label', (text) => text],
-  ['sortOrder.property', 'Sort by property', (rules) => <SortOrder rules={rules} />],
+  ['sortOrder', 'Sort by property', (rules) => <SortOrder rules={rules} />],
   ['binSortOrder', 'Bin sort order', (rules) => <SortOrder rules={rules} />],
   ['bucketSortOrder', 'Bucket sort order', (rules) => <SortOrder rules={rules} />],
   ['otherVariable', 'Other variable', (id) => <Variable id={id} />],

--- a/src/lib/ProtocolSummary/components/Stage/SkipLogic.js
+++ b/src/lib/ProtocolSummary/components/Stage/SkipLogic.js
@@ -16,6 +16,7 @@ const SkipLogic = ({ skipLogic }) => {
     <div className="protocol-summary-stage__skip-logic">
       <MiniTable
         rotated
+        wide
         rows={[
           ['Action', action],
           ['Rules', <Rules filter={filter} />],

--- a/src/lib/ProtocolSummary/components/Stage/Stage.js
+++ b/src/lib/ProtocolSummary/components/Stage/Stage.js
@@ -101,6 +101,7 @@ const Stage = ({
               <h2 className="section-heading">Network Filtering</h2>
               <MiniTable
                 rotated
+                wide
                 rows={[
                   ['Rules', <Filter filter={configuration.filter} />],
                 ]}

--- a/src/lib/ProtocolSummary/components/Variable.js
+++ b/src/lib/ProtocolSummary/components/Variable.js
@@ -1,22 +1,26 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+import { SimpleVariablePill } from '@components/Form/Fields/VariablePicker/VariablePill';
 import SummaryContext from './SummaryContext';
 import DualLink from './DualLink';
-import { getVariableName } from './helpers';
+import { getVariableName, getVariableMeta } from './helpers';
 
 const Variable = ({
   id,
 }) => {
+  if (!id) return null;
+
   const {
     index,
   } = useContext(SummaryContext);
+  const meta = getVariableMeta(index, id);
 
   return (
     <DualLink
       to={`#variable-${id}`}
       className="protocol-summary-variable"
     >
-      {getVariableName(index, id)}
+      <SimpleVariablePill label={getVariableName(index, id)} type={meta.type} />
     </DualLink>
   );
 };

--- a/src/lib/ProtocolSummary/components/Variables.js
+++ b/src/lib/ProtocolSummary/components/Variables.js
@@ -6,6 +6,7 @@ import {
   toPairs, get, find, isEmpty, sortBy,
 } from 'lodash';
 import Markdown from '@codaco/ui/lib/components/Fields/Markdown';
+import { SimpleVariablePill } from '@components/Form/Fields/VariablePicker/VariablePill';
 import SummaryContext from './SummaryContext';
 import DualLink from './DualLink';
 import MiniTable from './MiniTable';
@@ -73,7 +74,7 @@ const Variables = ({ variables }) => {
 
             return (
               <tr key={variableId} id={`variable-${variableId}`}>
-                <td>{name}</td>
+                <td><SimpleVariablePill label={name} type={type} /></td>
                 <td>
                   {type}
                   <br />

--- a/src/lib/ProtocolSummary/components/helpers.js
+++ b/src/lib/ProtocolSummary/components/helpers.js
@@ -16,6 +16,10 @@ export const getVariableName = (index, variableId) => {
   return entry && entry.name;
 };
 
+export const getVariableMeta = (index, variable) => (
+  index.find(({ id }) => id === variable) || {}
+);
+
 export const getEntityName = (codebook, entity, type) => (
   get(codebook, [entity, type, 'name'])
 );

--- a/src/lib/ProtocolSummary/styles/_protocol-summary.scss
+++ b/src/lib/ProtocolSummary/styles/_protocol-summary.scss
@@ -118,6 +118,12 @@
     font-family: -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
     font-size: 10pt;
   }
+
+  .variable-pill {
+    zoom: .8;
+    max-width: 24rem;
+    margin: .2rem;
+  }
 }
 
 .protocol-summary-controls {

--- a/src/lib/ProtocolSummary/styles/_protocol-summary.scss
+++ b/src/lib/ProtocolSummary/styles/_protocol-summary.scss
@@ -42,6 +42,14 @@
 }
 
 .protocol-summary-rules {
+  .protocol-summary-rules__rule {
+    --base-node-size: 5.6rem;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    flex-grow: 1;
+  }
+
   &__rule:not(:last-child) {
     margin-bottom: unit(1);
   }
@@ -122,7 +130,7 @@
   .variable-pill {
     zoom: .8;
     max-width: 24rem;
-    margin: .2rem;
+    margin: .5rem;
   }
 }
 


### PR DESCRIPTION
This fixes the existing variable pills in the protocol summary (for skip logic and filters), which were not getting the correct types and colors.

This also fixes the behaviors in the protocol summary to include the latest behaviors, and only to show behaviors relevant to the existing stage. It assumes relevance if the behavior is present.

Finally, this adds "pills" for all remaining variables in the protocol summary.

Screenshots from the development protocol:
![image](https://user-images.githubusercontent.com/16093053/161172045-12add6d4-3c34-4c83-9f76-a773f20720e2.png)

Another:
![image](https://user-images.githubusercontent.com/16093053/161172086-cbbfed3e-d888-4789-bcd4-0f6d17d54f11.png)

A third:
![image](https://user-images.githubusercontent.com/16093053/161172112-066836ca-8954-45c3-91d1-cce09bba745d.png)

Rinse:
![image](https://user-images.githubusercontent.com/16093053/161172130-acf6dce0-f771-4182-aae9-b102d7ea4d91.png)

Repeat:
![image](https://user-images.githubusercontent.com/16093053/161172186-09671dc9-1017-4dc4-ab91-c0764771b603.png)
