### PR TITLE
Update SUPPORTED_EXTENSION_TYPE_MAP to support m4a

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -26,6 +26,6 @@ export const APP_SCHEMA_VERSION = 7;
 export const SUPPORTED_EXTENSION_TYPE_MAP = {
   network: ['.csv', '.json'],
   image: ['.jpg', '.jpeg', '.gif', '.png'],
-  audio: ['.mp3', '.aiff', '.m4a', '.mp4'],
+  audio: ['.mp3', '.aiff', '.m4a'],
   video: ['.mov', '.mp4'],
 };


### PR DESCRIPTION
mp4 files can contain both video and audio. There is no clear way to
differentiate between them when importing an asset. Previously, we had
listed .mp4 extensions under both the audio and video extension type
map. Our naive lookup only ever matched with audio, which caused this
feature to be broken.

I explored looking up mimetype, but it turns out that mp4 always
returns video in this case. Since m4a is most commonly used for audio,
I updated the map so that mp4 is always video, and added m4a audio
support.