### PR TITLE
expand variable validation

### DIFF
--- a/src/__mocks__/config.js
+++ b/src/__mocks__/config.js
@@ -1,4 +1,4 @@
 /* eslint-env jest */
 /* eslint-disable import/prefer-default-export */
 
-export const APP_SCHEMA_VERSION = 7;
+export const APP_SCHEMA_VERSION = 8;

--- a/src/components/Validations/options.js
+++ b/src/components/Validations/options.js
@@ -8,6 +8,8 @@ const VALIDATIONS = {
     'unique',
     'differentFrom',
     'sameAs',
+    'lessThanVariable',
+    'greaterThanVariable',
   ],
   number: [
     'required',
@@ -16,18 +18,24 @@ const VALIDATIONS = {
     'unique',
     'differentFrom',
     'sameAs',
+    'lessThanVariable',
+    'greaterThanVariable',
   ],
   datetime: [
     'required',
     'unique',
     'differentFrom',
     'sameAs',
+    'lessThanVariable',
+    'greaterThanVariable',
   ],
   scalar: [
     'required',
     'unique',
     'differentFrom',
     'sameAs',
+    'lessThanVariable',
+    'greaterThanVariable',
   ],
   boolean: [
     'required',
@@ -40,6 +48,8 @@ const VALIDATIONS = {
     'unique',
     'differentFrom',
     'sameAs',
+    'lessThanVariable',
+    'greaterThanVariable',
   ],
   categorical: [
     'required',
@@ -63,6 +73,8 @@ const VALIDATIONS_WITH_NUMBER_VALUES = [
 const VALIDATIONS_WITH_LIST_VALUES = [
   'differentFrom',
   'sameAs',
+  'lessThanVariable',
+  'greaterThanVariable',
 ];
 
 const isValidationWithNumberValue = (validation) => (

--- a/src/components/sections/ValidationSection.js
+++ b/src/components/sections/ValidationSection.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import { change, formValueSelector } from 'redux-form';
+import { get, filter } from 'lodash';
 import { Section, Row } from '@components/EditorLayout';
 import Validations from '@components/Validations';
 import { getFieldId } from '../../utils/issues';
@@ -24,6 +25,7 @@ const ValidationSection = ({
     return true;
   };
 
+  const existingVariablesForType = filter(existingVariables, (variable) => get(variable, 'type') === variableType);
   return (
     <Section
       disabled={disabled}
@@ -43,7 +45,7 @@ const ValidationSection = ({
           form={form}
           name="validation"
           variableType={variableType}
-          existingVariables={existingVariables}
+          existingVariables={existingVariablesForType}
         />
       </Row>
     </Section>

--- a/src/components/sections/ValidationSection.js
+++ b/src/components/sections/ValidationSection.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import { change, formValueSelector } from 'redux-form';
-import { get, filter } from 'lodash';
+import { get, pickBy } from 'lodash';
 import { Section, Row } from '@components/EditorLayout';
 import Validations from '@components/Validations';
 import { getFieldId } from '../../utils/issues';
@@ -25,7 +25,7 @@ const ValidationSection = ({
     return true;
   };
 
-  const existingVariablesForType = filter(existingVariables, (variable) => get(variable, 'type') === variableType);
+  const existingVariablesForType = pickBy(existingVariables, (variable) => get(variable, 'type') === variableType);
   return (
     <Section
       disabled={disabled}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -20,7 +20,7 @@ export const COLOR_PALETTE_BY_ENTITY = {
 };
 
 // Target protocol schema version. Used to determine compatibility & migration
-export const APP_SCHEMA_VERSION = 7;
+export const APP_SCHEMA_VERSION = 8;
 
 // Maps for supported asset types within the app. Used by asset chooser.
 export const SUPPORTED_EXTENSION_TYPE_MAP = {


### PR DESCRIPTION
This adds "lessThanVariable" and "greaterThanVariable" to validation options. It allows this for datetime, ordinal, text, number, and scalar -- basically everything except categorical and boolean.

It constrains the variables that can be compared to the same type as the current variable.

It also updates protocol validation to [schema 8](https://github.com/complexdatacollective/protocol-validation/pull/55).