### PR TITLE
Fixes not able to close stage editor when filter disabled & validation that references variables

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -18,6 +18,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '2.7.18'
+      # update apt cache
+      - name: Update apt cache
+        run: sudo apt-get update -y
       # Set node version
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '2.7.18'
+      # update apt cache
+      - name: Update apt cache
+        run: sudo apt-get update -y
       # Set node version
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '2.7.18'
+      # update apt cache
+      - name: Update apt cache
+        run: sudo apt-get update -y
       # Set node version
       - uses: actions/setup-node@v2
         with:

--- a/src/components/Codebook/Codebook.js
+++ b/src/components/Codebook/Codebook.js
@@ -21,60 +21,60 @@ const Codebook = ({
   nodes,
 }) => (
   <div className="codebook">
-    { !hasEgoVariables && !hasNodes && !hasEdges
+    {!hasEgoVariables && !hasNodes && !hasEdges
       && (
-      <p className="codebook__notice">
-        There are currently no types or variables defined in this protocol.
-        When you have created some interview stages, the types and variables will be shown here.
-      </p>
+        <p className="codebook__notice">
+          There are currently no types or variables defined in this protocol.
+          When you have created some interview stages, the types and variables will be shown here.
+        </p>
       )}
-    { hasEgoVariables
+    {hasEgoVariables
       && (
-      <CodebookCategory title="Ego">
-        <EgoType entity="ego" type="ego" />
-      </CodebookCategory>
-      )}
-
-    { hasNodes
-      && (
-      <CodebookCategory title="Node Types">
-        {nodes.map((node) => (
-          <EntityType
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            {...node}
-            key={node.type}
-          />
-        ))}
-      </CodebookCategory>
+        <CodebookCategory title="Ego">
+          <EgoType entity="ego" type="ego" />
+        </CodebookCategory>
       )}
 
-    { hasEdges
+    {/* {hasNodes
       && (
-      <CodebookCategory title="Edge Types">
-        {edges.map((edge) => (
-          <EntityType
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            {...edge}
-            key={edge.type}
-          />
-        ))}
-      </CodebookCategory>
-      )}
-
-    { hasNetworkAssets
-      && (
-      <CodebookCategory title="Network Assets">
-        {networkAssets.map(
-          (networkAsset) => (
-            <ExternalEntity
-              id={networkAsset.id}
-              name={networkAsset.name}
-              key={networkAsset.id}
+        <CodebookCategory title="Node Types">
+          {nodes.map((node) => (
+            <EntityType
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...node}
+              key={node.type}
             />
-          ),
-        )}
-      </CodebookCategory>
+          ))}
+        </CodebookCategory>
       )}
+
+    {hasEdges
+      && (
+        <CodebookCategory title="Edge Types">
+          {edges.map((edge) => (
+            <EntityType
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...edge}
+              key={edge.type}
+            />
+          ))}
+        </CodebookCategory>
+      )}
+
+    {hasNetworkAssets
+      && (
+        <CodebookCategory title="Network Assets">
+          {networkAssets.map(
+            (networkAsset) => (
+              <ExternalEntity
+                id={networkAsset.id}
+                name={networkAsset.name}
+                key={networkAsset.id}
+              />
+            ),
+          )}
+        </CodebookCategory>
+      )} */}
 
   </div>
 );
@@ -92,9 +92,10 @@ Codebook.propTypes = {
   nodes: PropTypes.array.isRequired,
 };
 
+// TODO: replace this with helpers getEntityProperties. This code was
+// duplicated and needs to be reconciled.
 const getEntityWithUsage = (state, index, mergeProps) => {
   const search = utils.buildSearch([index]);
-
   return (_, id) => {
     const inUse = search.has(id);
 

--- a/src/components/Codebook/Codebook.js
+++ b/src/components/Codebook/Codebook.js
@@ -9,7 +9,12 @@ import EntityType from './EntityType';
 import ExternalEntity from './ExternalEntity';
 import EgoType from './EgoType';
 import CodebookCategory from './CodebookCategory';
-import { getStageMetaByIndex, getUsage, getUsageAsStageMeta, getVariableMetaByIndex } from './helpers';
+import {
+  getStageMetaByIndex,
+  getUsage,
+  getUsageAsStageMeta,
+  getVariableMetaByIndex,
+} from './helpers';
 
 const Codebook = ({
   edges,

--- a/src/components/Codebook/Codebook.js
+++ b/src/components/Codebook/Codebook.js
@@ -34,8 +34,7 @@ const Codebook = ({
           <EgoType entity="ego" type="ego" />
         </CodebookCategory>
       )}
-
-    {/* {hasNodes
+    {hasNodes
       && (
         <CodebookCategory title="Node Types">
           {nodes.map((node) => (
@@ -74,7 +73,7 @@ const Codebook = ({
             ),
           )}
         </CodebookCategory>
-      )} */}
+      )}
 
   </div>
 );

--- a/src/components/Codebook/Codebook.js
+++ b/src/components/Codebook/Codebook.js
@@ -34,6 +34,7 @@ const Codebook = ({
           <EgoType entity="ego" type="ego" />
         </CodebookCategory>
       )}
+
     {hasNodes
       && (
         <CodebookCategory title="Node Types">

--- a/src/components/Codebook/Codebook.js
+++ b/src/components/Codebook/Codebook.js
@@ -9,7 +9,7 @@ import EntityType from './EntityType';
 import ExternalEntity from './ExternalEntity';
 import EgoType from './EgoType';
 import CodebookCategory from './CodebookCategory';
-import { getUsage, getUsageAsStageMeta } from './helpers';
+import { getStageMetaByIndex, getUsage, getUsageAsStageMeta, getVariableMetaByIndex } from './helpers';
 
 const Codebook = ({
   edges,
@@ -99,8 +99,11 @@ const getEntityWithUsage = (state, index, mergeProps) => {
   return (_, id) => {
     const inUse = search.has(id);
 
+    const variableMeta = getVariableMetaByIndex(state);
+    const stageMetaByIndex = getStageMetaByIndex(state);
+
     const usage = inUse
-      ? getUsageAsStageMeta(state, getUsage(index, id))
+      ? getUsageAsStageMeta(stageMetaByIndex, variableMeta, getUsage(index, id))
       : [];
 
     return {

--- a/src/components/Codebook/EgoType.js
+++ b/src/components/Codebook/EgoType.js
@@ -9,15 +9,15 @@ const EgoType = ({
   variables,
 }) => (
   <div className="codebook__entity">
-    { variables.length > 0
+    {variables.length > 0
       && (
-      <div className="codebook__entity-variables codebook__entity-variables--no-border">
-        <h3>Variables:</h3>
-        <Variables
-          variables={variables}
-          entity="ego"
-        />
-      </div>
+        <div className="codebook__entity-variables codebook__entity-variables--no-border">
+          <h3>Variables:</h3>
+          <Variables
+            variables={variables}
+            entity="ego"
+          />
+        </div>
       )}
   </div>
 );
@@ -33,7 +33,7 @@ EgoType.defaultProps = {
 
 const mapStateToProps = (state) => {
   const entityProperties = getEntityProperties(state, { entity: 'ego' });
-
+  console.log('entityProperties', entityProperties);
   return entityProperties;
 };
 

--- a/src/components/Codebook/EgoType.js
+++ b/src/components/Codebook/EgoType.js
@@ -33,7 +33,6 @@ EgoType.defaultProps = {
 
 const mapStateToProps = (state) => {
   const entityProperties = getEntityProperties(state, { entity: 'ego' });
-  console.log('entityProperties', entityProperties);
   return entityProperties;
 };
 

--- a/src/components/Codebook/Tag.js
+++ b/src/components/Codebook/Tag.js
@@ -1,14 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Tag = ({ children }) => (<div className="codebook__tag">{children}</div>);
+const Tag = ({ children, notUsed = false }) => {
+  const classes = notUsed ? 'codebook__tag codebook__tag--not-used' : 'codebook__tag';
+  return (<div className={classes}>{children}</div>);
+};
 
 Tag.propTypes = {
   children: PropTypes.node,
+  notUsed: PropTypes.bool,
 };
 
 Tag.defaultProps = {
   children: null,
+  notUsed: false,
 };
 
 export default Tag;

--- a/src/components/Codebook/UsageColumn.js
+++ b/src/components/Codebook/UsageColumn.js
@@ -7,12 +7,21 @@ const UsageColumn = ({
   inUse,
   usage,
 }) => {
-  if (!inUse) { return (<Tag key="unused">not in use</Tag>); }
+  if (!inUse) { return (<Tag key="unused" notUsed>not in use</Tag>); }
 
   const stages = usage
-    .map(({ id, label }) => (
-      <ScreenLink screen="stage" id={id} key={id}>{label}</ScreenLink>
-    ));
+    .map(({ id, label }) => {
+      // If there is no id, don't create a link. This is the case for
+      // variables that are only in use as validation options.
+      if (!id) {
+        return (
+          <Tag key="validation-option">{label}</Tag>
+        );
+      }
+      return (
+        <ScreenLink screen="stage" id={id} key={id}>{label}</ScreenLink>
+      );
+    });
 
   return (
     <div className="codebook__variables-usage-container" key="usage">

--- a/src/components/Codebook/__tests__/helpers.test.js
+++ b/src/components/Codebook/__tests__/helpers.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { getUsage, getUsageAsStageMeta } from '../helpers';
+import { getUsage, getUsageAsStageMeta, getCodebookVariableIndexFromValidationPath } from '../helpers';
 
 const state = {
   protocol: {
@@ -35,4 +35,21 @@ it('getUsageAsStageMeta()', () => {
     { label: 'bar', id: 'efgh' },
   ];
   expect(getUsageAsStageMeta(state, usage)).toEqual(expectedResult);
+});
+
+it('getCodebookVariableIndexFromValidationPath()', () => {
+  const testStrings = [
+    "codebook.ego.variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.sameAs",
+    "codebook.ego.variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.differentFrom",
+    "codebook.node[nodeType].variables[variableType].validation.sameAs",
+    "codebook.node[nodeType].variables[variableType].validation.differentFrom",
+    "codebook.edge[edgeType].variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.sameAs",
+    "codebook.edge[edgeType].variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.differentFrom",
+  ];
+
+  // Run the function for each string in the array
+  testStrings.forEach((testString) => {
+    expect(getCodebookVariableIndexFromValidationPath(testString)).toEqual('4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c');
+  }
+
 });

--- a/src/components/Codebook/__tests__/helpers.test.js
+++ b/src/components/Codebook/__tests__/helpers.test.js
@@ -1,10 +1,41 @@
 /* eslint-env jest */
 
-import { getUsage, getUsageAsStageMeta, getCodebookVariableIndexFromValidationPath } from '../helpers';
+import { getAllVariablesByUUID } from '../../../selectors/codebook';
+import { getUsage, getUsageAsStageMeta } from '../helpers';
 
 const state = {
   protocol: {
     present: {
+      codebook: {
+        ego: {
+          variables: {
+            1: {
+              name: 'name',
+              type: 'text',
+            },
+          },
+        },
+        node: {
+          person: {
+            variables: {
+              2: {
+                name: 'name',
+                type: 'text',
+              },
+            },
+          },
+        },
+        edge: {
+          friend: {
+            variables: {
+              3: {
+                name: 'name',
+                type: 'text',
+              },
+            },
+          },
+        },
+      },
       stages: [
         { label: 'foo', id: 'abcd', other: 'ignored' },
         { label: 'bar', id: 'efgh', other: 'ignored' },
@@ -30,26 +61,22 @@ it('getUsage() ', () => {
 
 it('getUsageAsStageMeta()', () => {
   const usage = ['stages[0].foo.bar', 'stages[0].foo.bar.bazz', 'stages[1].foo.bar.bazz'];
+
+  const mockStageMetaByIndex = [
+    { label: 'foo', id: 'abcd' },
+    { label: 'bar', id: 'efgh' },
+    { label: 'bazz', id: 'ijkl' },
+  ];
+
+  const mockVariableMetaByIndex = getAllVariablesByUUID(state.protocol.present.codebook);
+
   const expectedResult = [
     { label: 'foo', id: 'abcd' },
     { label: 'bar', id: 'efgh' },
   ];
-  expect(getUsageAsStageMeta(state, usage)).toEqual(expectedResult);
-});
-
-it('getCodebookVariableIndexFromValidationPath()', () => {
-  const testStrings = [
-    "codebook.ego.variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.sameAs",
-    "codebook.ego.variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.differentFrom",
-    "codebook.node[nodeType].variables[variableType].validation.sameAs",
-    "codebook.node[nodeType].variables[variableType].validation.differentFrom",
-    "codebook.edge[edgeType].variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.sameAs",
-    "codebook.edge[edgeType].variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.differentFrom",
-  ];
-
-  // Run the function for each string in the array
-  testStrings.forEach((testString) => {
-    expect(getCodebookVariableIndexFromValidationPath(testString)).toEqual('4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c');
-  }
-
+  expect(getUsageAsStageMeta(
+    mockStageMetaByIndex,
+    mockVariableMetaByIndex,
+    usage,
+  )).toEqual(expectedResult);
 });

--- a/src/components/Codebook/helpers.js
+++ b/src/components/Codebook/helpers.js
@@ -72,23 +72,27 @@ export const getEntityProperties = (state, { entity, type }) => {
   const variableIndex = getVariableIndex(state);
   const isUsedIndex = getIsUsed(state);
 
-  console.log('isUsedIndex', isUsedIndex, variableIndex);
-
   const variablesWithUsage = map(
     variables,
     (variable, id) => {
       const inUse = get(isUsedIndex, id, false);
 
-      const usage = inUse
-        ? getUsageAsStageMeta(state, getUsage(variableIndex, id)).sort(sortByLabel)
-        : [];
-
-      const usageString = usage.map(({ label }) => label).join(', ').toUpperCase();
-
-      return ({
+      const baseProperties = {
         ...variable,
         id,
         inUse,
+      };
+
+      if (!inUse) {
+        return (baseProperties);
+      }
+
+      const thing = getUsage(variableIndex, id);
+      const usage = getUsageAsStageMeta(state, thing).sort(sortByLabel);
+      const usageString = usage.map(({ label }) => label).join(', ').toUpperCase();
+
+      return ({
+        ...baseProperties,
         usage,
         usageString,
       });

--- a/src/components/Codebook/helpers.js
+++ b/src/components/Codebook/helpers.js
@@ -29,9 +29,25 @@ const getStageIndexFromPath = (path) => {
   return get(matches, 1, null);
 };
 
+export const getCodebookVariableIndexFromValidationPath = (path) => {
+  // Regexp that matches all of the following:
+  // "codebook.ego.variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.sameAs"
+  // "codebook.ego.variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.differentFrom"
+  // "codebook.node[nodeType].variables[variableType].validation.sameAs"
+  // "codebook.node[nodeType.variables[variableType].validation.differentFrom"
+  // "codebook.edge[edgeType].variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.sameAs"
+  // "codebook.edge[edgeType].variables[4b27bf9f-7058-4e74-84d8-2cc0bfd7d25c].validation.differentFrom"
+
+  // eslint-disable-next-line max-len
+  const matches = /codebook\.(ego|node\[([^\]]+)\]|edge\[([^\]]+)\])\.variables\[([^\]]+)\]\.validation\.(sameAs|differentFrom)/.exec(path);
+  return get(matches, 1, null);
+};
+
 /**
- * Filters a usage index for items that match value.
- * @param {Object.<string, string>}} index Usage index in (in format `{[path]: value}`)
+ * Takes an object in the format of `{[path]: variableID}` and a variableID to
+ * search for. Returns an array of paths that match the variableID.
+ *
+ * @param {Object.<string, string>}} index Usage index in (in format `{[path]: variableID}`)
  * @param {any} value Value to match in usage index
  * @returns {string[]} List of paths ("usage array")
  */
@@ -41,37 +57,70 @@ export const getUsage = (index, value) => reduce(index, (acc, indexValue, path) 
 }, []);
 
 /**
- * Get stage meta that matches "usage array" (deduped).
- * See `getUsage()` for details of usage array,
+ * Get stage meta (wtf is stage meta, Steve? 🤦) that matches "usage array"
+ * (with duplicates removed).
+ *
+ * See `getUsage()` for how the usage array is generated.
+ *
  * Any stages that can't be found in the index are omitted.
  * @param {Object} state Application state
- * @param {string[]} usage "Usage array"
+ * @param {string[]} usageArray "Usage array" as created by `getUsage()`
  * @returns {Object[]} List of stage meta `{ label, id }`.
  */
-export const getUsageAsStageMeta = (state, usage) => {
+export const getUsageAsStageMeta = (state, usageArray) => {
+  console.log('usageArray', usageArray);
   const stageMetaByIndex = getStageMetaByIndex(state);
-  const stageIndexes = compact(uniq(usage.map(getStageIndexFromPath)));
-  return stageIndexes.map((stageIndex) => get(stageMetaByIndex, stageIndex));
+
+  // Filter codebook variables from usage array
+  const codebookVariablePaths = usageArray.filter(getCodebookVariableIndexFromValidationPath);
+
+  const codebookVariablesWithMeta = codebookVariablePaths.map((path) => {
+    console.log('codebookVariables:', path);
+    return {
+      label: 'Used as validation for variable',
+    };
+  });
+
+  const stageIndexes = compact(uniq(usageArray.map(getStageIndexFromPath)));
+  const stageVariablesWithMeta = stageIndexes.map((stageIndex) => get(stageMetaByIndex, stageIndex));
+
+  return [
+    ...stageVariablesWithMeta,
+    ...codebookVariablesWithMeta,
+  ];
 };
 
-// Function to be used with Array.sort. Sorts a collection of variable
-// definitions by the label property.
+/**
+ * Helper function to be used with Array.sort. Sorts a collection of variable
+ * definitions by the label property.
+ *
+ * @param {Object} a { label: string }
+ * @param {Object} b { label: string }
+ * @returns {number} -1 if a < b, 1 if a > b, 0 if a === b
+ */
 export const sortByLabel = (a, b) => {
   if (a.label < b.label) { return -1; }
   if (a.label > b.label) { return 1; }
   return 0;
 };
 
+/**
+ * Returns entity meta data for use in the codebook.
+ * @param {*} state
+ * @param {*} param1
+ * @returns
+ */
 export const getEntityProperties = (state, { entity, type }) => {
   const {
     name,
     color,
     variables,
   } = getType(state, { entity, type });
+  console.log('getEntityProperties', entity, type);
 
   const variableIndex = getVariableIndex(state);
   const isUsedIndex = getIsUsed(state);
-
+  console.log('variableIndex', variableIndex);
   const variablesWithUsage = map(
     variables,
     (variable, id) => {
@@ -90,7 +139,6 @@ export const getEntityProperties = (state, { entity, type }) => {
       const thing = getUsage(variableIndex, id);
       const usage = getUsageAsStageMeta(state, thing).sort(sortByLabel);
       const usageString = usage.map(({ label }) => label).join(', ').toUpperCase();
-
       return ({
         ...baseProperties,
         usage,

--- a/src/components/Codebook/helpers.js
+++ b/src/components/Codebook/helpers.js
@@ -72,6 +72,8 @@ export const getEntityProperties = (state, { entity, type }) => {
   const variableIndex = getVariableIndex(state);
   const isUsedIndex = getIsUsed(state);
 
+  console.log('isUsedIndex', isUsedIndex, variableIndex);
+
   const variablesWithUsage = map(
     variables,
     (variable, id) => {

--- a/src/components/Query/ruleValidator.js
+++ b/src/components/Query/ruleValidator.js
@@ -1,14 +1,21 @@
 import { get } from 'lodash';
 
 const validateRules = (value) => {
-  const rules = get(value, 'rules', []);
+  // BUGFIX: If the section containing the filter is not expanded, we set
+  // the filter value to null. In this case, we don't want to
+  // validate the filter, because it will be invisible and will simply
+  // prevent the form from being submitted without an error.
+  if (!value) {
+    return undefined;
+  }
+  const rules = get(value, 'rules');
   const join = get(value, 'join');
 
-  if (rules.length > 1 && !join) {
+  if (rules && rules.length > 1 && !join) {
     return 'Please select a join type';
   }
 
-  if (rules.length === 0) {
+  if (rules && rules.length === 0) {
     return 'Please create at least one rule';
   }
 

--- a/src/components/Validations/withStoreState.js
+++ b/src/components/Validations/withStoreState.js
@@ -1,7 +1,5 @@
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { formValueSelector, change } from 'redux-form';
-import { actionCreators as dialogsActions } from '../../ducks/modules/dialogs';
 import { getValidationOptionsForVariableType } from './options';
 
 const mapStateToProps = (state, {
@@ -15,7 +13,6 @@ const mapStateToProps = (state, {
 };
 
 const mapDispatchToProps = (dispatch, { form, name }) => ({
-  openDialog: bindActionCreators(dialogsActions.openDialog, dispatch),
   update: (value) => dispatch(change(form, name, value)),
 });
 

--- a/src/components/Validations/withUpdateHandlers.js
+++ b/src/components/Validations/withUpdateHandlers.js
@@ -43,16 +43,9 @@ const getUpdatedValue = (previousValue, key, value, oldKey = null) => {
 };
 
 const withUpdateHandlers = withHandlers({
-  handleDelete: ({ openDialog, update, value: previousValue }) => (key) => {
+  handleDelete: ({ update, value: previousValue }) => (key) => {
     const newValue = omit(previousValue, key);
-
-    openDialog({
-      type: 'Warning',
-      title: 'Remove validation',
-      message: 'Are you sure you want to remove this rule?',
-      onConfirm: () => { update(newValue); },
-      confirmLabel: 'Remove validation',
-    });
+    update(newValue);
   },
   handleChange: ({ update, value: previousValue }) => (key, value, oldKey) => {
     const newValue = getUpdatedValue(previousValue, key, value, oldKey);

--- a/src/components/Validations/withUpdateHandlers.js
+++ b/src/components/Validations/withUpdateHandlers.js
@@ -2,10 +2,37 @@ import { omit } from 'lodash';
 import { withHandlers } from 'recompose';
 import { isValidationWithListValue, isValidationWithNumberValue } from './options';
 
+/**
+ * Function called when a validation is added or updated. Returns a value
+ * based on the validation type, and the previous value (if any).
+ *
+ * @param {string} type - The validation type.
+ * @param {string} oldType - The previous validation type.
+ * @param {string} value - The current value.
+ * @returns {string} The new value.
+ */
+const getAutoValue = (type, oldType, value) => {
+  // Required is special - always return true.
+  if (type === 'required') {
+    return true;
+  }
+
+  // If the new type and the old type are both numbers, keep the value
+  if (isValidationWithNumberValue(type) && isValidationWithNumberValue(oldType)) {
+    return value;
+  }
+
+  // If the new type and the old type both reference variables, keep the value.
+  if (isValidationWithListValue(type) && isValidationWithListValue(oldType)) {
+    return value;
+  }
+
+  // Otherwise, set an empty value to force the user to enter a value.
+  return null;
+};
+
 const getUpdatedValue = (previousValue, key, value, oldKey = null) => {
-  const autoValue = isValidationWithNumberValue(key) || isValidationWithListValue(key)
-    ? value
-    : true;
+  const autoValue = getAutoValue(key, oldKey, value);
 
   if (!oldKey) { return { ...previousValue, [key]: autoValue }; }
 

--- a/src/components/sections/ValidationSection.js
+++ b/src/components/sections/ValidationSection.js
@@ -18,7 +18,7 @@ const ValidationSection = ({
   const getFormValue = formValueSelector(form);
   const hasValidation = useSelector((state) => {
     const validation = getFormValue(state, 'validation');
-    return validation && Object.keys(pickBy(validation)).length > 0;
+    return validation && Object.keys(validation).length > 0;
   });
 
   const handleToggleValidation = (nextState) => {

--- a/src/selectors/__tests__/__snapshots__/indexes.test.js.snap
+++ b/src/selectors/__tests__/__snapshots__/indexes.test.js.snap
@@ -67,6 +67,9 @@ Object {
 
 exports[`indexes selectors getVariableIndex() extracts variables into index 1`] = `
 Object {
+  "codebook.edge[77199445-9d50-4646-b0bc-6d6b0c0e06bd].variables[e343a91f-628d-4175-870c-957beffa0003].validation.sameAs": "e343a91f-628d-4175-870c-957beffa0002",
+  "codebook.ego.variables[9c47f32e-b72f-4b1b-93a2-e29766dc3012].validation.differentFrom": "23a10bcb-bd71-46a1-a36d-4ab80cb5a1d1",
+  "codebook.node[4aebf73e-95e3-4fd1-95e7-237dcc4a4466].variables[0e75ec18-2cb1-4606-9f18-034d28b07c19].validation.differentFrom": "6be95f85-c2d9-4daf-9de1-3939418af888",
   "stages[0].form.fields[0].variable": "3377af3f-3c79-41da-9b0b-6570fb519b93",
   "stages[0].form.fields[10].variable": "9c47f32e-b72f-4b1b-93a2-e29766dc3012",
   "stages[0].form.fields[1].variable": "b4956387-cada-412f-9e97-fe352c3cc44e",

--- a/src/selectors/codebook/__tests__/variables.test.js
+++ b/src/selectors/codebook/__tests__/variables.test.js
@@ -6,8 +6,18 @@ const variable1 = '1234-1234-1234-1';
 const variable2 = '1234-1234-1234-2';
 const variable3 = '1234-1234-1234-3';
 const variable4 = '1234-1234-1234-4';
+const variable5 = '1234-1234-1234-5';
+const variable6 = '1234-1234-1234-6';
+const variable7 = '1234-1234-1234-7';
+const variable8 = '1234-1234-1234-8';
 
 const mockCodebookWithoutUse = {
+  ego: {
+    variables: {
+      [variable5]: {},
+      [variable6]: {},
+    },
+  },
   node: {
     person: {
       variables: {
@@ -15,6 +25,14 @@ const mockCodebookWithoutUse = {
         [variable2]: {},
         [variable3]: {},
         [variable4]: {},
+      },
+    },
+  },
+  edge: {
+    friendship: {
+      variables: {
+        [variable7]: {},
+        [variable8]: {},
       },
     },
   },
@@ -51,6 +69,10 @@ describe('makeGetIsUsed', () => {
       [variable2]: false,
       [variable3]: false,
       [variable4]: false,
+      [variable5]: false,
+      [variable6]: false,
+      [variable7]: false,
+      [variable8]: false,
     });
   });
 
@@ -90,6 +112,10 @@ describe('makeGetIsUsed', () => {
       [variable2]: true,
       [variable3]: true,
       [variable4]: false,
+      [variable5]: false,
+      [variable6]: false,
+      [variable7]: false,
+      [variable8]: false,
     });
   });
 
@@ -123,6 +149,10 @@ describe('makeGetIsUsed', () => {
           [variable2]: true,
           [variable3]: true,
           [variable4]: false,
+          [variable5]: false,
+          [variable6]: false,
+          [variable7]: false,
+          [variable8]: false,
         });
       });
 
@@ -135,6 +165,10 @@ describe('makeGetIsUsed', () => {
           [variable2]: false,
           [variable3]: false,
           [variable4]: false,
+          [variable5]: false,
+          [variable6]: false,
+          [variable7]: false,
+          [variable8]: false,
         });
       });
     });
@@ -143,17 +177,22 @@ describe('makeGetIsUsed', () => {
   it('checks codebook for variable validation use', () => {
     const stateWithCodebookUse = {
       ...mockStateWithoutUse,
-      codebook: {
-        ...mockCodebookWithoutUse,
-        node: {
-          ...mockCodebookWithoutUse.node,
-          person: {
-            ...mockCodebookWithoutUse.node.person,
-            variables: {
-              ...mockCodebookWithoutUse.node.person.variables,
-              [variable1]: {
-                validation: {
-                  sameAs: variable2,
+      protocol: {
+        ...mockProtocolWithoutUse,
+        present: {
+          codebook: {
+            ...mockCodebookWithoutUse,
+            node: {
+              ...mockCodebookWithoutUse.node,
+              person: {
+                ...mockCodebookWithoutUse.node.person,
+                variables: {
+                  ...mockCodebookWithoutUse.node.person.variables,
+                  [variable1]: {
+                    validation: {
+                      sameAs: variable2,
+                    },
+                  },
                 },
               },
             },
@@ -169,6 +208,10 @@ describe('makeGetIsUsed', () => {
       [variable2]: true,
       [variable3]: false,
       [variable4]: false,
+      [variable5]: false,
+      [variable6]: false,
+      [variable7]: false,
+      [variable8]: false,
     });
   });
 

--- a/src/selectors/codebook/helpers.js
+++ b/src/selectors/codebook/helpers.js
@@ -4,6 +4,11 @@ import { flatMap } from 'lodash';
 
 const getIdsFromEntity = (entity) => (entity.variables ? Object.keys(entity.variables) : []);
 
+/**
+ *
+ * @param {*} codebook
+ * @returns
+ */
 export const getIdsFromCodebook = (codebook) => flatMap(
   codebook,
   (entityOrEntities, type) => (

--- a/src/selectors/codebook/isUsed.js
+++ b/src/selectors/codebook/isUsed.js
@@ -5,14 +5,23 @@ import { getIdsFromCodebook } from './helpers';
 
 /**
  * Gets a key value object describing variables are
- * in use (including in redux forms)
- * @returns {object} in format: { [variableId]: boolean }
+ * in use (including in redux forms).
+ *
+ * Naive implementation: just checks if the variable id is in the flattened
+ * protocol, or any redux forms.
+ *
+ * @param {object} options  - options object
+ * @param {Array} options.formNames - names of forms to check for variable usage
+ * @param {Array} options.excludePaths - paths to exclude from the check (e.g. 'stages')
+ *
+ * @returns {function} - selector function that returns a key value object
+ * describing variables are in use
  */
-export const makeGetIsUsed = (isUsedOptions = {}) => (state) => {
+export const makeGetIsUsed = (options = {}) => (state) => {
   const {
     formNames = ['edit-stage', 'editable-list-form'],
     excludePaths = [],
-  } = isUsedOptions;
+  } = options;
 
   const protocol = getProtocol(state);
   const forms = getForms(formNames)(state);

--- a/src/selectors/codebook/isUsed.js
+++ b/src/selectors/codebook/isUsed.js
@@ -1,6 +1,6 @@
-import { get, omit, cloneDeep } from 'lodash';
+import { get, omit, cloneDeep, each } from 'lodash';
 import { getForms } from '../reduxForm';
-import { getProtocol } from '../protocol';
+import { getCodebook, getProtocol } from '../protocol';
 import { getIdsFromCodebook } from './helpers';
 
 /**
@@ -9,6 +9,11 @@ import { getIdsFromCodebook } from './helpers';
  *
  * Naive implementation: just checks if the variable id is in the flattened
  * protocol, or any redux forms.
+ *
+ * JRM BUGFIX: This previously did not check for `sameAs` or `differentFrom`
+ * variable references that are contained within codebook variable definitions.
+ * This caused a bug where these variables were able to be removed, creating
+ * references to variables that no longer existed.
  *
  * @param {object} options  - options object
  * @param {Array} options.formNames - names of forms to check for variable usage
@@ -26,10 +31,44 @@ export const makeGetIsUsed = (options = {}) => (state) => {
   const protocol = getProtocol(state);
   const forms = getForms(formNames)(state);
   const variableIds = getIdsFromCodebook(protocol.codebook);
+  const codebook = getCodebook(state);
+
+  // Get all codebook[entityType][entityId].variables.validation references
+  const variableValidations = () => {
+    const validations = [];
+    const getEntityVariableValidations = (entityDefinition) => {
+      if (!entityDefinition.variables) {
+        return [];
+      }
+
+      return Object.values(entityDefinition.variables).reduce((memo, variable) => {
+        if (variable.validation) {
+          memo.push(variable.validation);
+        }
+        return memo;
+      }, []);
+    };
+
+    Object.keys(codebook).forEach((entityType) => {
+      if (entityType === 'ego') {
+        validations.push(...getEntityVariableValidations(codebook[entityType]));
+      }
+
+      Object.keys(codebook[entityType]).forEach((entityId) => {
+        validations.push(...getEntityVariableValidations(codebook[entityType][entityId]));
+      });
+    });
+
+    return validations;
+  };
+
+  const searchLocations = { stages: protocol.stages, forms, validations: variableValidations() };
 
   const data = excludePaths.length > 0
-    ? omit(cloneDeep({ stages: protocol.stages, forms }), excludePaths)
-    : { stages: protocol.stages, forms };
+    ? omit(cloneDeep(
+      searchLocations,
+    ), excludePaths)
+    : searchLocations;
 
   const flattenedData = JSON.stringify(data);
 

--- a/src/selectors/codebook/isUsed.js
+++ b/src/selectors/codebook/isUsed.js
@@ -1,4 +1,4 @@
-import { get, omit, cloneDeep, each } from 'lodash';
+import { get, omit, cloneDeep } from 'lodash';
 import { getForms } from '../reduxForm';
 import { getCodebook, getProtocol } from '../protocol';
 import { getIdsFromCodebook } from './helpers';

--- a/src/selectors/indexes.js
+++ b/src/selectors/indexes.js
@@ -95,10 +95,7 @@ const getNodeIndex = createSelector(
  */
 const getVariableIndex = createSelector(
   getProtocol,
-  (protocol) => {
-    console.log('getVariableIndex', collectPaths(paths.variables, protocol));
-    return collectPaths(paths.variables, protocol);
-  },
+  (protocol) => collectPaths(paths.variables, protocol),
 );
 
 /**

--- a/src/selectors/indexes.js
+++ b/src/selectors/indexes.js
@@ -60,8 +60,10 @@ export const paths = {
     // `sameAs` and `differentFrom` are variable references in these locations
     'codebook.ego.variables[].validation.sameAs',
     'codebook.ego.variables[].validation.differentFrom',
-    'codebook.node.[].variables[].validation.sameAs',
-    'codebook.edge.[].variables[].validation.differentFrom',
+    'codebook.node[].variables[].validation.sameAs',
+    'codebook.node[].variables[].validation.differentFrom',
+    'codebook.edge[].variables[].validation.sameAs',
+    'codebook.edge[].variables[].validation.differentFrom',
   ],
   assets: [
     'stages[].panels[].dataSource',

--- a/src/selectors/indexes.js
+++ b/src/selectors/indexes.js
@@ -58,9 +58,10 @@ export const paths = {
     'stages[].presets[].edges.display[]',
     'stages[].presets[].highlight[]',
     // `sameAs` and `differentFrom` are variable references in these locations
-    'codebook.ego.variables[].validation',
-    'codebook.node.[].variables[].validation',
-    'codebook.edge.[].variables[].validation',
+    'codebook.ego.variables[].validation.sameAs',
+    'codebook.ego.variables[].validation.differentFrom',
+    'codebook.node.[].variables[].validation.sameAs',
+    'codebook.edge.[].variables[].validation.differentFrom',
   ],
   assets: [
     'stages[].panels[].dataSource',
@@ -94,7 +95,10 @@ const getNodeIndex = createSelector(
  */
 const getVariableIndex = createSelector(
   getProtocol,
-  (protocol) => collectPaths(paths.variables, protocol),
+  (protocol) => {
+    console.log('getVariableIndex', collectPaths(paths.variables, protocol));
+    return collectPaths(paths.variables, protocol);
+  },
 );
 
 /**

--- a/src/selectors/indexes.js
+++ b/src/selectors/indexes.js
@@ -14,9 +14,13 @@ const mapAssetItems = ({ type, content }, path) => {
 };
 
 /**
- * Locations of referenceable entities in a standard protocol.
+ * Master list of paths where variables are used.
  *
- * This is generally used to find which entities are used where.
+ * ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+ * It is VITAL that this be updated when any new variable use occurs in the
+ * protocol schema!
+ * ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+ *
  */
 export const paths = {
   edges: [
@@ -53,6 +57,10 @@ export const paths = {
     'stages[].presets[].groupVariable',
     'stages[].presets[].edges.display[]',
     'stages[].presets[].highlight[]',
+    // `sameAs` and `differentFrom` are variable references in these locations
+    'codebook.ego.variables[].validation',
+    'codebook.node.[].variables[].validation',
+    'codebook.edge.[].variables[].validation',
   ],
   assets: [
     'stages[].panels[].dataSource',

--- a/src/selectors/reduxForm.js
+++ b/src/selectors/reduxForm.js
@@ -1,9 +1,25 @@
-import { getFormValues } from 'redux-form';
+import { getFormValues, getFormNames } from 'redux-form';
 
-export const getForms = (formNames = []) => (state) => formNames.reduce(
-  (memo, formName) => ({
-    ...memo,
-    [formName]: getFormValues(formName)(state),
-  }),
-  {},
-);
+/**
+ * Returns the redux form values for the given form names.
+ * If no form names are given, returns all form values.
+ * @param {Array} formNames - names of forms to get values for
+ * @returns {function} - selector function that returns an object of form values
+ * keyed by form name
+ */
+export const getForms = (formNames) => (state) => {
+  const reduce = (names) => names.reduce(
+    (memo, formName) => ({
+      ...memo,
+      [formName]: getFormValues(formName)(state),
+    }),
+    {},
+  );
+
+  if (!formNames) {
+    const allFormNames = getFormNames(state);
+    return reduce(allFormNames);
+  }
+
+  return reduce(formNames);
+};

--- a/src/styles/components/_codebook.scss
+++ b/src/styles/components/_codebook.scss
@@ -20,7 +20,6 @@
     font-size: .9em;
     color: var(--color-white);
     background-color: var(--color-mustard--dark);
-    text-transform: lowercase;
 
     &--not-used {
       background-color: var(--architect-warning);

--- a/src/styles/components/_codebook.scss
+++ b/src/styles/components/_codebook.scss
@@ -16,10 +16,11 @@
   &__tag {
     display: inline-block;
     border-radius: unit(1);
-    padding: unit(0.5) unit(0.75);
+    padding: unit(.5) unit(.75);
     font-size: .9em;
     color: var(--color-white);
     background-color: var(--color-mustard--dark);
+    word-break: break-word;
 
     &--not-used {
       background-color: var(--architect-warning);
@@ -160,6 +161,10 @@
           }
         }
       }
+    }
+
+    &--usage {
+      max-width: 300px;
     }
 
     &-usage-container {

--- a/src/styles/components/_codebook.scss
+++ b/src/styles/components/_codebook.scss
@@ -15,13 +15,16 @@
 
   &__tag {
     display: inline-block;
-    border-radius: unit(.5);
-    padding: .1em .3em;
-    margin-top: -.05em;
+    border-radius: unit(1);
+    padding: unit(0.5) unit(0.75);
     font-size: .9em;
-    color: var(--text-light);
-    background-color: var(--architect-warning);
+    color: var(--color-white);
+    background-color: var(--color-mustard--dark);
     text-transform: lowercase;
+
+    &--not-used {
+      background-color: var(--architect-warning);
+    }
   }
 
   &__category {
@@ -164,6 +167,10 @@
       display: flex;
       flex-direction: column;
       align-items: flex-start;
+
+      > * {
+        margin: .25rem;
+      }
     };
   }
 


### PR DESCRIPTION
## Bugs Fixed in this PR

### Disabling the "filter" from the node side panel removes the "save button" from the stage editor

Redux form still validates fields that are not shown, even when their value is null. We set fields to invisible with a value of null when they are contained within a toggleable section, in order to "disable" them.

Redux form has no concept of disabling a field.

In this case, the hidden field representing the node panel filter was still being validated, and the validation function was returning a string indicating that the field was empty (because we set it to null in order to reset it!). This error was hidden from the user, because the field was hidden and deregistered.

The fix is to change the validation function to return undefined if the value is null. Could also have been implemented as passing undefined as the validation prop to the field based on if the toggleable section is open or closed.

### Changing a variable type

This bug was caused by failing to correctly rest the validation value when the validation type was changed. It caused extremely strange (and invalid) behaviour when switching between types.

The fix here was to create a new function to calculate the "automatic" valid of validations that are created/changed to correctly set a value in `withUpdateHandlers`. This function attempts to keep the value if the type of the previous and current validation is the same, but otherwise resets it to null, which requires the user to create a new value.

### Variables that are only used as validation for other variables are still able to be deleted. This creates an invalid protocol

We did not check for variable use in the codebook, where variables can be referenced as validation targets when using `sameAs` or `differentFrom`. This meant that these variables could be deleted, causing an invalid protocol via a dangling reference. 

The fix was to include codebook variable paths in the search tree for variables, and to update the logic for calculating if a variable is in use (as well as identifying _where_ it is used) to account for these locations. This was a complicated fix!