### PR TITLE
Release/6.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.4.5",
+    "version": "6.4.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.4.5",
+    "version": "6.4.6",
     "productName": "Network Canvas Architect",
     "description": "A tool for building Network Canvas interviews.",
     "author": "Complex Data Collective <info@networkcanvas.com>",

--- a/public/package.json
+++ b/public/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-architect",
-    "version": "6.4.5",
+    "version": "6.4.6",
     "productName": "Network Canvas Architect",
     "description": "A tool for building Network Canvas interviews.",
     "author": "Complex Data Collective",


### PR DESCRIPTION
This release of Architect provides several small bug fixes and should be installed by anyone using version 6.4.0 or above.

### Changelog:

- Fixed an issue where skip logic section allowed skip logic to be configured with no rules, causing an invalid protocol.
- Updated preview mode version of Interviewer to 6.4.2 to fix an issue where skip logic was not being evaluated properly for ego categorical variables.